### PR TITLE
Set repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
+  "repository": "https://github.com/mmun/ember-presenters.git",
   "scripts": {
     "build": "ember build",
     "start": "ember server",


### PR DESCRIPTION
This is so NPM picks up the URL and lets things like Ember Observer get this.